### PR TITLE
Fix notification_settings schema mismatch and installer upgrade auto-apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@
   - GET直打ち時は404ではなく詳細画面へ誘導するフォールバック導線を追加
 - ファイル共有リンク画面を専用表示へ変更し、ログイン状態に関わらず他メニューが表示されないよう修正
 - 限定リンクで管理者が全共有リンクへアクセスできるよう権限判定を改善
+- `notification_settings` スキーマに `schedule_view_start_time` / `schedule_view_end_time` を追加し、`Models/Notification.php` との不整合を解消
+- インストーラで `db/upgrade_*.sql` を自動適用する処理を追加し、初回導入時の不足テーブル/カラムによるSQLエラーを防止
 
 ### i18n / 多言語
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -331,6 +331,8 @@ CREATE TABLE IF NOT EXISTS notification_settings (
     notify_workflow BOOLEAN NOT NULL DEFAULT 1 COMMENT 'ワークフロー通知',
     notify_message BOOLEAN NOT NULL DEFAULT 1 COMMENT 'メッセージ通知',
     email_notify BOOLEAN NOT NULL DEFAULT 1 COMMENT 'メール通知',
+    schedule_view_start_time TIME NOT NULL DEFAULT '00:00:00' COMMENT '通知対象の開始時刻',
+    schedule_view_end_time TIME NOT NULL DEFAULT '23:00:00' COMMENT '通知対象の終了時刻',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE

--- a/db/upgrade_20260325_schedule_display_settings.sql
+++ b/db/upgrade_20260325_schedule_display_settings.sql
@@ -1,3 +1,31 @@
-ALTER TABLE notification_settings
-    ADD COLUMN schedule_view_start_time TIME NOT NULL DEFAULT '00:00:00' AFTER email_notify,
-    ADD COLUMN schedule_view_end_time TIME NOT NULL DEFAULT '23:00:00' AFTER schedule_view_start_time;
+SET @col_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'notification_settings'
+      AND COLUMN_NAME = 'schedule_view_start_time'
+);
+SET @sql := IF(
+    @col_exists = 0,
+    "ALTER TABLE notification_settings ADD COLUMN schedule_view_start_time TIME NOT NULL DEFAULT '00:00:00' AFTER email_notify",
+    'DO 0'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'notification_settings'
+      AND COLUMN_NAME = 'schedule_view_end_time'
+);
+SET @sql := IF(
+    @col_exists = 0,
+    "ALTER TABLE notification_settings ADD COLUMN schedule_view_end_time TIME NOT NULL DEFAULT '23:00:00' AFTER schedule_view_start_time",
+    'DO 0'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/public/install.php
+++ b/public/install.php
@@ -27,6 +27,53 @@ function verifyCsrf(): bool {
     return isset($_POST['csrf_token']) && hash_equals($_SESSION['install_csrf_token'], $_POST['csrf_token']);
 }
 
+/**
+ * Normalize SQL before execution in installer context.
+ * - Remove UTF-8 BOM.
+ * - Remove CREATE DATABASE / USE statements because the DB is already selected.
+ */
+function normalizeInstallSql(string $sql): string {
+    $sql = preg_replace('/^\xEF\xBB\xBF/', '', $sql);
+    $sql = preg_replace('/^\s*CREATE\s+DATABASE\s+.*?;\s*$/mi', '', $sql);
+    $sql = preg_replace('/^\s*USE\s+.*?;\s*$/mi', '', $sql);
+    return $sql;
+}
+
+/**
+ * Apply db/upgrade_*.sql files in filename order.
+ *
+ * @return array<int, string> Applied file names.
+ * @throws RuntimeException When an upgrade file fails.
+ */
+function applyUpgradeScripts(PDO $pdo, string $dbDir): array {
+    $files = glob(rtrim($dbDir, '/') . '/upgrade_*.sql');
+    if (!$files) {
+        return [];
+    }
+    sort($files, SORT_STRING);
+
+    $applied = [];
+    foreach ($files as $file) {
+        $basename = basename($file);
+        $sql = @file_get_contents($file);
+        if ($sql === false) {
+            throw new RuntimeException("アップグレードSQLの読み込みに失敗しました: {$basename}");
+        }
+        $sql = normalizeInstallSql($sql);
+        if (trim($sql) === '') {
+            continue;
+        }
+        try {
+            $pdo->exec($sql);
+            $applied[] = $basename;
+        } catch (PDOException $e) {
+            throw new RuntimeException("アップグレードSQLの適用に失敗しました ({$basename}): " . $e->getMessage());
+        }
+    }
+
+    return $applied;
+}
+
 // ========== AJAX: Test Database Connection ==========
 if (isset($_POST['action']) && $_POST['action'] === 'test_db') {
     header('Content-Type: application/json');
@@ -108,9 +155,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['install_step'])) {
                         $schemaFile = $rootDir . '/db/schema.sql';
                         if (file_exists($schemaFile)) {
                             $sql = file_get_contents($schemaFile);
-                            // Remove CREATE DATABASE and USE statements (we already selected the DB)
-                            $sql = preg_replace('/^\s*CREATE\s+DATABASE\s+.*?;\s*$/mi', '', $sql);
-                            $sql = preg_replace('/^\s*USE\s+.*?;\s*$/mi', '', $sql);
+                            $sql = normalizeInstallSql((string)$sql);
                             $pdo->exec($sql);
                         } else {
                             $errors[] = 'スキーマファイルが見つかりません: db/schema.sql';
@@ -253,6 +298,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['install_step'])) {
                     foreach ($settingsData as $row) {
                         $stmt->execute($row);
                     }
+
+                    // Apply post-schema upgrade scripts for feature completeness.
+                    applyUpgradeScripts($pdo, $rootDir . '/db');
 
                     // 4. Create install.lock
                     file_put_contents($rootDir . '/install.lock', date('Y-m-d H:i:s') . "\nInstalled by: " . $admin['username']);


### PR DESCRIPTION
## Summary
- add missing `schedule_view_start_time` and `schedule_view_end_time` columns to `notification_settings` in `db/schema.sql`
- make `db/upgrade_20260325_schedule_display_settings.sql` idempotent (safe if columns already exist)
- update installer to auto-apply all `db/upgrade_*.sql` files after schema + admin setup
- update changelog

## Why
- resolves schema mismatch causing SQL errors in `Models/Notification.php`
- prevents missing-table/missing-column errors on fresh installs where upgrade scripts were previously not applied

Fixes #19
Fixes #20
